### PR TITLE
Update db-embeddings.py

### DIFF
--- a/ciscolive-demo/documentation-llm/training/db-embeddings.py
+++ b/ciscolive-demo/documentation-llm/training/db-embeddings.py
@@ -12,7 +12,7 @@ def create_database(db_name, user, password, host="db", port="5432"):
     For initialization
     '''
     # Connect to the PostgreSQL server
-    conn = psycopg2.connect(database="postgres", user=user, password=password, host=host, port=port)
+    conn = psycopg2.connect(database="postgres", user=user, password=password, host='localhost', port=port)
     conn.autocommit = True  # Enable autocommit mode to execute the CREATE DATABASE command
 
     # Create a new cursor


### PR DESCRIPTION
Either  update the  /etc/hosts  file  or update this with  'localhost' instead of  host  to  get  rid of  the  below  error. 

127.0.0.1 postgres or 127.0.0.1 <name_of_your_pg_host>

So that when ever my Mac gets a request to look for postgres it maps it to localhost and works.




ERROR:
======

(base) akram@ISHERIFF-M-RBNA training % 
(base) akram@ISHERIFF-M-RBNA training % python pdf.py python db-embeddings.py
Processing file 1: cisco-nexus-dashboard-release-notes-301.pdf Cisco Nexus Dashboard Release Notes, Release 3.0.1 o
Processed 1 documents.
Script execution completed successfully.
Traceback (most recent call last):
  File "/Users/akram/AKRAM_CODE_FOLDER/LLAMA_LLM_CPP/ciscolive/ciscolive-demo/documentation-llm/training/db-embeddings.py", line 179, in <module>
    main()
  File "/Users/akram/AKRAM_CODE_FOLDER/LLAMA_LLM_CPP/ciscolive/ciscolive-demo/documentation-llm/training/db-embeddings.py", line 170, in main
    create_database('cisco_embeddings', 'postgres', 'secret', 'db', '5432')
  File "/Users/akram/AKRAM_CODE_FOLDER/LLAMA_LLM_CPP/ciscolive/ciscolive-demo/documentation-llm/training/db-embeddings.py", line 15, in create_database
    conn = psycopg2.connect(database="postgres", user=user, password=password, host=localhost, port=port)
                                                                                    ^^^^^^^^^
NameError: name 'localhost' is not defined. Did you mean: 'locals'? (base) akram@ISHERIFF-M-RBNA training % 


Once  change is done, then it  starts to work  fine. 
(base) akram@ISHERIFF-M-RBNA training % python pdf.py python db-embeddings.py
Processing file 1: cisco-nexus-dashboard-release-notes-301.pdf Cisco Nexus Dashboard Release Notes, Release 3.0.1 o
Processed 1 documents.
Script execution completed successfully.
An error occurred: database "cisco_embeddings" already exists

Processing line 0: Source: Cisco Nexus Dashboard Release Notes, Release 3.0.1
Found source: Source: Cisco Nexus Dashboard Release Notes, Release 3.0.1 Release Notes, Release 3.0.1
Found header: New Software Features
Found content: This release adds the following new features: Product Impact Feature Description Base Functionality Support for pure IPv6 and dual stack IPv4/IPv6 configurations While prior releases supported either pure IPv4 or dual stack IPv4/IPv6 for management network only, this release adds support for pure IPv6 or dual stack IPv4/IPv6 configurations for the cluster nodes and services. Note that this feature is supported for greenfield deployments only. Security NTP Authentication Nexus Dashboard now supports NTP authentication using symmetrical keys. Reliability Additional Syslog Messages The following additional events can now be streamed to a Syslog server: ●  Cluster node is unreachable. ●  Cluster node is rebooted. ●  All audit events. ●  NTP is not synchronized. © 2020 Cisco and/or its affiliates. All rights reserved. Page 3 of 10 Product Impact Feature Description ●  BGP peers are not reachable. Ease of Use UI look-and-feel improvements This release adds product GUI improvements, including the getting started journey map.
Found header: Changes in Behavior
Found content: If you are installing or upgrading to this release, you must consider the following: ● If you are running Nexus Dashboard Insights service in a virtual Nexus Dashboard cluster, you must deploy a new Nexus Dashboard virtual cluster to install Nexus Dashboard Insights release 6.3(1). Virtual Nexus Dashboard deployment for NDI release 6.3.1 requires a greenfield installation of Nexus Dashboard cluster. Upgrade of virtual Nexus Dashboard cluster to run NDI release 6.3.1 is not supported. ● If you are running Nexus Dashboard Insights service in a physical Nexus Dashboard cluster, you must upgrade to release 3.0(1i) of Nexus Dashboard before upgrading the Insights service to 6.3(1). Nexus Dashboard release 3.0(1f) does not support any existing Nexus Dashboard Insights releases; to install or upgrade the Insight service, you must use Nexus Dashboard release 3.0(1i). ● If you are running Nexus Dashboard Insights service in a 4-node physical cluster, you can simply upgrade the cluster and the service to this release as you typically would and continue using the 4- node cluster. Nexus Dashboard release 3.0(1) with Nexus Dashboard Insights supports only 3-node and 6-node profiles for greenfield deployments. However, if you are upgrading an existing 4-node cluster from release 2.x without changing your current scale, you can continue using it with release 3.0(1). ●  Virtual Nexus Dashboard clusters do not support cohosting of multiple services in this Nexus Dashboard release. For detailed cohosting information, see the Nexus Dashboard Capacity Planning tool. ●  Before upgrading your existing Nexus Dashboard cluster to this release, you must disable all services running in the cluster. You must keep the services disabled until the platform is upgraded to this release and then upgrade the services to the releases compatible with this Nexus Dashboard release before re-enabling them. ●  After upgrading to this release, you must upgrade all the services to the versions compatible with this Nexus Dashboard release. For compatible releases, see the Cisco Nexus Dashboard and Services Compatibility Matrix. © 2020 Cisco and/or its affiliates. All rights reserved. Page 4 of 10 ●  The default CIMC password for Nexus Dashboard physical nodes based on the UCS-225-M6 hardware is "Insieme123". ●  Nexus Dashboard does not support platform downgrades.
Found header: Open Issues
Found content: This section lists the open issues. Click the bug ID to access the Bug Search Tool and see additional information about the issue. The "Exists In" column of the table specifies the releases in which the issue exists. Bug ID                 Description CSCvx93124 You may see the following error: [2021-04-13 13:48:20,170] ERROR Error while appending records to stats-6 in dir /data/services/kafka/data/0 (kafka.server.LogDirFailureChannel) java.io.IOException: No space left on device Exists in 3.0(1f) and later CSCwf91890  You may see an "Invalid key, key must be PEM encoded PKCS1 or PKCS8 private key" error on the login screen when login is attempted after disaster recovery (DR) is completed. 3.0(1f) and later CSCwe65177 In rare cases a system may remain in an unhealthy state after reboot or upgrade because kubernetes is unable to launch new containers. 3.0(1f) and later This will show up as pods having persistent ContainerCreate errors over the course of 10 or more minutes, which do not resolve on their own. CSCwh13418  When performing a manual upgrade, you may get 'Could not clear stale upgrade data' error while running the 'acs installer post-update' command. CSCwh28363  After a clean reboot of a node, the node can fail to come up. Additional reboot can resolve the issue. CSCwh23260  The pods in event manager namespace are crashing or are not in ready state CSCwh53145  The in-product documentation that is available from the Nexus Dashboard help center contains a number of broken links. CSCwi63356  High memory utilization on some but not all nodes after node failover. 3.0(1f) and later 3.0(1f) and later 3.0(1f) and later 3.0(1f) and later 3.0(1f) and later
Found header: Resolved Issues
Found content: This section lists the resolved issues. Click the bug ID to access the Bug Search tool and see additional information about the issue. The "Fixed In" column of the table specifies whether the bug was resolved in the base release or a patch release. © 2020 Cisco and/or its affiliates. All rights reserved. Page 5 of 10 Bug ID                 Description Fixed in CSCwe71125 If you restart multiple services at the same time, you may encounter a "Failed to enable service" error in the UI. 3.0(1f) Additionally, you may see a "Cannot support required scale for this service on current Nexus Dashboard deployment. However, service can be started with limited capacity. Please check the documentation for more details". This error message doesn't reflect the real issue with the system, and the scale configuration may be still valid. CSCwd48788  Error during local tar file upload for RHEL platform. 3.0(1f)
Found header: Known Issues
Found content: This section lists known behaviors. Click the Bug ID to access the Bug Search Tool and see additional information about the issue. Bug ID                 Description CSCvy62110 For Nexus Dashboard nodes connected to Catalyst switches packets are tagged with vlan0 even though no VLAN is specified. This causes no reachability over the data network. In this case, 'switchport voice vlan dot1p' command must be added to the switch interfaces where the nodes are connected. CSCvw39822  On power cycle system lvm initialization may fail due to a slowness in the disks. CSCvw48448  Upgrade fails and cluster is in diverged state with one or more nodes on the target version. CSCvw57953  When the system is being recovered with a clean reboot of all nodes, the admin login password will be reset to the day0 password that is entered during the bootstrap of the cluster. CSCvw70476  When bringing up ND cluster first time, all three primary nodes need to join Kafka cluster before any primary node can be rebooted. Failing to do so, 2 node cluster doesn't become healthy as Kafka cluster requires 3 nodes to be in Kafka cluster first time. CSCvx89368  After ND upgrade, there will be still pods belonging to the older version running on the cluster. CSCvx98282 Pods in pending state for a long period upon restart. These pods are usually stateful sets that require specific node placement and capacity must be available on the specific node they are first scheduled. This happens when multiple applications are installed on the same ND cluster and the ND capacity overloaded. CSCvu21304 Intersight device connector connects to the Intersight over the Cisco Application Services Engine Out-Of- Band Management. CSCwe04619  The 'acs health' command may show a service as unhealthy and kubectl (available in the Tech Support collection) shows the service is in ContainerCreateError state. CSCwd84875  Two Nodes RMA requires manual intervention. CSCwb31373  After node failover, kubernetes scheduling may be unable to find appropriate resources for the pods in an app. The symptom is that the app health will not converge and kubectl commands will show unhealthy pods. © 2020 Cisco and/or its affiliates. All rights reserved. Page 6 of 10
Found header: Compatibility
Found content: Nexus Dashboard release 3.0(1f) does not support any existing Nexus Dashboard Insights releases; to install or upgrade the Insight service, you must use Nexus Dashboard release 3.0(1i). For Cisco Nexus Dashboard services compatibility information, see the Cisco Nexus Dashboard and Services Compatibility Matrix. For Cisco Nexus Dashboard cluster sizing guidelines and the list of supported services for each cluster form factor, see the Nexus Dashboard Capacity Planning tool. Physical Nexus Dashboard nodes support Cisco UCS-220-M5 and UCS-225-M6 servers. Physical Nexus Dashboard nodes must be running a supported version of Cisco Integrated Management Controller (CIMC). This release supports CIMC releases 4.2(3b), 4.2(3e), and 4.3(2.230207). VMware vMotion is not supported for Nexus Dashboard nodes deployed in VMware ESX. Cisco UCS-C220-M3 and earlier servers are not supported for Virtual Nexus Dashboard clusters. Browser Compatibility The Cisco Nexus Dashboard and services UI is intended to be compatible with the most recent desktop version of most common browsers, including Chrome, Firefox, Edge, and Safari. In most cases, compatibility will extend one version behind their most recent release. While not designed for compatibility with mobile devices, most mobile browsers are still able to render majority of Nexus Dashboard and services UI. However, using the above-listed browsers on a desktop or laptop is recommended. Mobile browsers aren’t officially supported by Cisco Nexus Dashboard and services.
Found header: Verified Scalability Limits
Found content: The following table lists the maximum verified scalability limits for the Nexus Dashboard platform. Category Scale Number of primary and worker nodes in a cluster Depends on cluster form factor and the specific services enabled in the cluster. See the Nexus Dashboard Capacity Planning tool for detailed information. Number of standby nodes in a cluster For physical cluster, up to 2 standby nodes For virtual and cloud clusters, standby nodes are not supported Sites per cluster Depends on the specific services deployed in the cluster: ●  For Nexus Dashboard Orchestrator, see the Nexus Dashboard Orchestrator Verified Scalability Guide for a specific release. ●  For Nexus Dashboard Fabric Controller, see the Verified Scalability Guide for Cisco Nexus Dashboard Fabric Controller for a specific release. ●  For Nexus Dashboard Insights, see the Release Notes for a specific release. © 2020 Cisco and/or its affiliates. All rights reserved. Page 7 of 10 Category Admin users Operator users Service instances API sessions Login domains Clusters connected via multi-cluster connectivity Sites across all clusters connected via multi-cluster connectivity Scale 50 1000 4 2000 for Nexus Dashboard and Nexus Dashboard Orchestrator 100 for Nexus Dashboard Insights 8 4 12 Maximum latency between any two clusters connected via multi-cluster connectivity 500ms
modules.json: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 229/229 [00:00<00:00, 362kB/s]
config_sentence_transformers.json: 100%|███████████████████████████████████████████████████████████████████████████████████████████████| 122/122 [00:00<00:00, 551kB/s]
README.md: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 3.69k/3.69k [00:00<00:00, 19.0MB/s]
sentence_bert_config.json: 100%|████████████████████